### PR TITLE
Add getkirby/composer-installer as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "homepage": "https://kirby.hananils.de/plugins/methods-folder",
     "require": {
+        "getkirby/composer-installer": "^1.2",
         "php": "^8.2"
     },
     "config": {


### PR DESCRIPTION
v3.0 doesn't add the plugin to the plugins folder when installing it with composer